### PR TITLE
docs: Fix simple typo, migraions -> migrations

### DIFF
--- a/tests/test_plan/test_all_migrations.py
+++ b/tests/test_plan/test_all_migrations.py
@@ -7,7 +7,7 @@ from django_test_migrations.plan import all_migrations, nodes_to_tuples
 
 @pytest.mark.django_db
 def test_all_migrations_main():
-    """Testing migraions for a single app only."""
+    """Testing migrations for a single app only."""
     main_migrations = all_migrations('default', ['main_app'])
 
     assert nodes_to_tuples(main_migrations) == [
@@ -20,19 +20,19 @@ def test_all_migrations_main():
 
 @pytest.mark.django_db
 def test_all_migrations_missing():
-    """Testing migraions for a missing app."""
+    """Testing migrations for a missing app."""
     with pytest.raises(LookupError):
         all_migrations('default', ['missing_app'])
 
 
 @pytest.mark.django_db
 def test_all_migrations_auth():
-    """Testing migraions for a builtin app."""
+    """Testing migrations for a builtin app."""
     auth_migrations = all_migrations('default', ['auth'])
     assert len(auth_migrations) >= 10
 
 
 @pytest.mark.django_db
 def test_all_migrations_all():
-    """Testing migraions for all apps."""
+    """Testing migrations for all apps."""
     assert len(all_migrations()) >= 17  # noqa: WPS432


### PR DESCRIPTION
There is a small typo in tests/test_plan/test_all_migrations.py.

Should read `migrations` rather than `migraions`.

