### PR TITLE
Enable providing migration dependencies as a list, while preserving backward compatibility

### DIFF
--- a/django_test_migrations/migrator.py
+++ b/django_test_migrations/migrator.py
@@ -70,7 +70,7 @@ class Migrator(object):
         with _mute_migrate_signals():
             return self._executor.migrate(migrate_from)
 
-    def after(self, migrate_to: _Migration) -> ProjectState:
+    def after(self, migrate_to: _MigrationSpec) -> ProjectState:
         """Apply the next migration."""
         self._executor.loader.build_graph()  # reload.
         return self.before(migrate_to)

--- a/django_test_migrations/migrator.py
+++ b/django_test_migrations/migrator.py
@@ -64,8 +64,10 @@ class Migrator(object):
 
     def before(self, migrate_from: _Migration) -> ProjectState:
         """Reverse back to the original migration."""
+        if type(migrate_from) is not list:
+            migrate_from = [migrate_from]
         with _mute_migrate_signals():
-            return self._executor.migrate([migrate_from])
+            return self._executor.migrate(migrate_from)
 
     def after(self, migrate_to: _Migration) -> ProjectState:
         """Apply the next migration."""

--- a/django_test_migrations/migrator.py
+++ b/django_test_migrations/migrator.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from contextlib import contextmanager
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple, Union
 
 from django.core.management import call_command
 from django.db import DEFAULT_DB_ALIAS, connections
@@ -12,6 +12,7 @@ from django.db.models.signals import post_migrate, pre_migrate
 # Regular or rollback migration: 0001 -> 0002, or 0002 -> 0001
 # Rollback migration to initial state: 0001 -> None
 _Migration = Tuple[str, Optional[str]]
+_MigrationSpec = Union[_Migration, List[_Migration]]
 
 
 @contextmanager
@@ -62,9 +63,9 @@ class Migrator(object):
         self._database: str = database
         self._executor = MigrationExecutor(connections[self._database])
 
-    def before(self, migrate_from: _Migration) -> ProjectState:
+    def before(self, migrate_from: _MigrationSpec) -> ProjectState:
         """Reverse back to the original migration."""
-        if type(migrate_from) is not list:
+        if not isinstance(migrate_from, list):
             migrate_from = [migrate_from]
         with _mute_migrate_signals():
             return self._executor.migrate(migrate_from)

--- a/tests/test_migrator/test_migrator.py
+++ b/tests/test_migrator/test_migrator.py
@@ -16,3 +16,15 @@ def test_migrator(transactional_db):
     assert isinstance(old_state, ProjectState)
     assert isinstance(new_state, ProjectState)
     assert migrator.reset() is None
+
+
+@pytest.mark.django_db
+def test_migrator_list(transactional_db):
+    """We only need this test for coverage."""
+    migrator = Migrator()
+    old_state = migrator.before([('main_app', None)])
+    new_state = migrator.after([('main_app', '0001_initial')])
+
+    assert isinstance(old_state, ProjectState)
+    assert isinstance(new_state, ProjectState)
+    assert migrator.reset() is None


### PR DESCRIPTION
While testing a mildly complex migration, I have been faced with an issue: the models in old_state between related fields would not be compatible.

I would get the following error:
`ValueError: Cannot assign "<Event: Event object (55fb676e-8d17-4df2-942f-c3b61d872a4a)>": "Session.event" must be a "Event" instance.`

An extract of the models is below
```
class Event(models.Model):
    name = models.CharField(max_length=200, blank=False)
    other_app = models.ForeignKey(
        'other_app.Model', on_delete=models.SET_NULL, null=True, blank=True,
    )

class Session(models.Model):
    name = models.CharField(max_length=200, blank=False,)
    event = models.ForeignKey(Event, on_delete=models.CASCADE)
```

After quite some debugging, the issue was linked to an earlier migration that created the `other_app` ForeignKey in `Event`. That migration had obviously two dependencies, one on the previous migration of `Event`, one on the migration of the other app.

Setting `migrate_from` to migrations before the other_app Foreignkey would work like a charm. Setting it to later migrations raised an error.

I have been able to solve the problem by enabling passing a list of migrations to `before()`: the migrations of both apps.

I have proposed a simple fix in the attached PR, which tries to preserve backward compatibility. 

I have tried to reproduce the issue on a more simple case, but I haven't been able to reproduce the issue. (I cannot share my working models and migrations).