### PR TITLE
Correct `post_migrate` signal muting

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ That's a testing tool after all!
 Note that the Django `post_migrate` signal's receiver list is cleared at
 the start of tests and restored afterwards. If you need to test your
 own `post_migrate` signals then attach/remove them during a test.
+
 ### pytest
 
 We ship `django-test-migrations` with a `pytest` plugin

--- a/README.md
+++ b/README.md
@@ -153,6 +153,9 @@ and apps that depend on each other will be executed in the correct order.
 We support several test frameworks as first-class citizens.
 That's a testing tool after all!
 
+Note that the Django `post_migrate` signal's receiver list is cleared at
+the start of tests and restored afterwards. If you need to test your
+own `post_migrate` signals then attach/remove them during a test.
 ### pytest
 
 We ship `django-test-migrations` with a `pytest` plugin

--- a/django_test_migrations/contrib/pytest_plugin.py
+++ b/django_test_migrations/contrib/pytest_plugin.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 import pytest
 from django.db import DEFAULT_DB_ALIAS
-from django.db.models.signals import post_migrate, pre_migrate
+from django.db.models.signals import post_migrate
 
 
 @pytest.fixture()
@@ -50,12 +50,8 @@ def _mute_migration_signals():
     restore_post, post_migrate.receivers = (  # noqa: WPS414
         post_migrate.receivers, [],
     )
-    restore_pre, pre_migrate.receivers = (  # noqa: WPS414
-        pre_migrate.receivers, [],
-    )
     yield
     post_migrate.receivers = restore_post
-    pre_migrate.receivers = restore_pre
 
 
 @pytest.fixture()

--- a/django_test_migrations/contrib/unittest_case.py
+++ b/django_test_migrations/contrib/unittest_case.py
@@ -3,6 +3,7 @@
 from typing import ClassVar, Optional
 
 from django.db.migrations.state import ProjectState
+from django.db.models.signals import post_migrate
 from django.test import TransactionTestCase
 
 from django_test_migrations.migrator import (  # noqa: WPS436
@@ -49,3 +50,13 @@ class MigratorTestCase(TransactionTestCase):
 
         Used to prepare some data before the migration process.
         """
+
+    def _pre_setup(self):
+        self._post_migrate_receivers, post_migrate.receivers = (  # noqa: WPS414
+            post_migrate.receivers, [],
+        )
+        super()._pre_setup()
+
+    def _post_teardown(self):
+        super()._post_teardown()
+        post_migrate.receivers = self._post_migrate_receivers

--- a/tests/test_contrib/test_pytest_plugin/test_plugin.py
+++ b/tests/test_contrib/test_pytest_plugin/test_plugin.py
@@ -2,6 +2,8 @@
 
 import subprocess
 
+from django.db.models.signals import post_migrate
+
 
 def test_call_pytest_setup_plan():
     """Checks that module is registered and visible in the meta data."""
@@ -25,5 +27,4 @@ def test_call_pytest_setup_plan():
 
 def test_signal_muting(migrator):
     """Checks that `post_migrate` signal has been muted."""
-    from django.db.models.signals import post_migrate
     assert post_migrate.receivers == []

--- a/tests/test_contrib/test_pytest_plugin/test_plugin.py
+++ b/tests/test_contrib/test_pytest_plugin/test_plugin.py
@@ -21,3 +21,9 @@ def test_call_pytest_setup_plan():
 
     assert 'migrator' in output_text
     assert 'migrator_factory' in output_text
+
+
+def test_signal_muting(migrator):
+    """Checks that `post_migrate` signal has been muted."""
+    from django.db.models.signals import post_migrate
+    assert post_migrate.receivers == []

--- a/tests/test_contrib/test_pytest_plugin/test_plugin.py
+++ b/tests/test_contrib/test_pytest_plugin/test_plugin.py
@@ -27,4 +27,4 @@ def test_call_pytest_setup_plan():
 
 def test_signal_muting(migrator):
     """Checks that `post_migrate` signal has been muted."""
-    assert post_migrate.receivers == []
+    assert not post_migrate.receivers

--- a/tests/test_contrib/test_unittest_case/test_unittest_case.py
+++ b/tests/test_contrib/test_unittest_case/test_unittest_case.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from django.db.models.signals import post_migrate
 from django_test_migrations.contrib.unittest_case import MigratorTestCase
 
 
@@ -40,3 +41,17 @@ class TestBackwardMigration(MigratorTestCase):
         SomeItem = self.new_state.apps.get_model('main_app', 'SomeItem')
 
         assert SomeItem.objects.count() == 2
+
+
+class TestSignalMuting(MigratorTestCase):
+    """This class is used to test that the `post_migrate` signal
+    has been muted.
+    """
+
+    migrate_from = ('main_app', '0002_someitem_is_clean')
+    migrate_to = ('main_app', '0001_initial')
+
+    def test_post_migrate_muted(self):
+        """Confirm that there are no signal handlers for `post_migrate`"""
+        assert post_migrate.receivers == []
+        assert len(self._post_migrate_receivers) > 0

--- a/tests/test_contrib/test_unittest_case/test_unittest_case.py
+++ b/tests/test_contrib/test_unittest_case/test_unittest_case.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from django.db.models.signals import post_migrate
+
 from django_test_migrations.contrib.unittest_case import MigratorTestCase
 
 
@@ -44,14 +45,12 @@ class TestBackwardMigration(MigratorTestCase):
 
 
 class TestSignalMuting(MigratorTestCase):
-    """This class is used to test that the `post_migrate` signal
-    has been muted.
-    """
+    """Test that the `post_migrate` signal has been muted."""
 
     migrate_from = ('main_app', '0002_someitem_is_clean')
     migrate_to = ('main_app', '0001_initial')
 
     def test_post_migrate_muted(self):
-        """Confirm that there are no signal handlers for `post_migrate`"""
-        assert post_migrate.receivers == []
-        assert len(self._post_migrate_receivers) > 0
+        """Confirm that there are no signal handlers for `post_migrate`."""
+        assert not post_migrate.receivers
+        assert self._post_migrate_receivers


### PR DESCRIPTION
This resolves #68

It changes the behavior to muting the `post_migrate` signal, by clearing its receivers list, prior to the execution of the test. The receivers list remains cleared until after test cleanup, when it is restored.

Notably only the `post_migrate` signal is cleared. I removed the code that cleared the `pre_migrate` signal as it is not fired by `TransactionTestCase` (and `transactional_db`).

As I am not familiar with contributing to this project there might be some oddities, please feel free to point them out.