### PR TITLE
rename Migrator before and after methods

### DIFF
--- a/django_test_migrations/contrib/pytest_plugin.py
+++ b/django_test_migrations/contrib/pytest_plugin.py
@@ -16,8 +16,10 @@ def migrator_factory(request, transactional_db, django_db_use_migrations):
         @pytest.mark.django_db
         def test_migration(migrator_factory):
             migrator = migrator_factory('custom_db_alias')
-            old_state = migrator.before(('main_app', None))
-            new_state = migrator.after(('main_app', '0001_initial'))
+            old_state = migrator.apply_initial_migration(('main_app', None))
+            new_state = migrator.apply_tested_migration(
+                ('main_app', '0001_initial'),
+            )
 
             assert isinstance(old_state, ProjectState)
             assert isinstance(new_state, ProjectState)
@@ -55,8 +57,10 @@ def migrator(migrator_factory):  # noqa: WPS442
 
         @pytest.mark.django_db
         def test_migration(migrator):
-            old_state = migrator.before(('main_app', None))
-            new_state = migrator.after(('main_app', '0001_initial'))
+            old_state = migrator.apply_initial_migration(('main_app', None))
+            new_state = migrator.apply_tested_migration(
+                ('main_app', '0001_initial'),
+            )
 
             assert isinstance(old_state, ProjectState)
             assert isinstance(new_state, ProjectState)

--- a/django_test_migrations/contrib/unittest_case.py
+++ b/django_test_migrations/contrib/unittest_case.py
@@ -31,9 +31,11 @@ class MigratorTestCase(TransactionTestCase):
         """
         super().setUp()
         self._migrator = Migrator(self.database_name)
-        self.old_state = self._migrator.before(self.migrate_from)
+        self.old_state = self._migrator.apply_initial_migration(
+            self.migrate_from,
+        )
         self.prepare()
-        self.new_state = self._migrator.after(self.migrate_to)
+        self.new_state = self._migrator.apply_tested_migration(self.migrate_to)
 
     def prepare(self) -> None:
         """

--- a/tests/test_contrib/test_pytest_plugin/test_pytest_plugin_reverse.py
+++ b/tests/test_contrib/test_pytest_plugin/test_pytest_plugin_reverse.py
@@ -12,12 +12,14 @@ from django.core.exceptions import FieldError
 @pytest.mark.django_db
 def test_pytest_plugin0001(migrator):
     """Ensures that the first migration works."""
-    old_state = migrator.before(('main_app', '0002_someitem_is_clean'))
+    old_state = migrator.apply_initial_migration(
+        ('main_app', '0002_someitem_is_clean'),
+    )
     SomeItem = old_state.apps.get_model('main_app', 'SomeItem')
 
     assert SomeItem.objects.filter(is_clean=True).count() == 0
 
-    new_state = migrator.after(('main_app', '0001_initial'))
+    new_state = migrator.apply_tested_migration(('main_app', '0001_initial'))
     SomeItem = new_state.apps.get_model('main_app', 'SomeItem')
 
     with pytest.raises(FieldError):
@@ -27,7 +29,9 @@ def test_pytest_plugin0001(migrator):
 @pytest.mark.django_db
 def test_pytest_plugin0002(migrator):
     """Ensures that the second migration works."""
-    old_state = migrator.before(('main_app', '0003_update_is_clean'))
+    old_state = migrator.apply_initial_migration(
+        ('main_app', '0003_update_is_clean'),
+    )
     SomeItem = old_state.apps.get_model('main_app', 'SomeItem')
     SomeItem.objects.create(string_field='a', is_clean=True)
     SomeItem.objects.create(string_field='a b', is_clean=False)
@@ -35,7 +39,9 @@ def test_pytest_plugin0002(migrator):
     assert SomeItem.objects.count() == 2
     assert SomeItem.objects.filter(is_clean=True).count() == 1
 
-    new_state = migrator.after(('main_app', '0002_someitem_is_clean'))
+    new_state = migrator.apply_tested_migration(
+        ('main_app', '0002_someitem_is_clean'),
+    )
     SomeItem = new_state.apps.get_model('main_app', 'SomeItem')
 
     assert SomeItem.objects.count() == 2

--- a/tests/test_migrator/test_migrator.py
+++ b/tests/test_migrator/test_migrator.py
@@ -8,8 +8,8 @@ from django_test_migrations.migrator import Migrator
 def test_migrator(transactional_db):
     """We only need this test for coverage."""
     migrator = Migrator()
-    old_state = migrator.before(('main_app', None))
-    new_state = migrator.after(('main_app', '0001_initial'))
+    old_state = migrator.apply_initial_migration(('main_app', None))
+    new_state = migrator.apply_tested_migration(('main_app', '0001_initial'))
 
     assert isinstance(old_state, ProjectState)
     assert isinstance(new_state, ProjectState)
@@ -20,8 +20,8 @@ def test_migrator(transactional_db):
 def test_migrator_list(transactional_db):
     """We only need this test for coverage."""
     migrator = Migrator()
-    old_state = migrator.before([('main_app', None)])
-    new_state = migrator.after([('main_app', '0001_initial')])
+    old_state = migrator.apply_initial_migration([('main_app', None)])
+    new_state = migrator.apply_tested_migration([('main_app', '0001_initial')])
 
     assert isinstance(old_state, ProjectState)
     assert isinstance(new_state, ProjectState)


### PR DESCRIPTION
Rename ``Migrator`` methods:

+ ``before`` to ``apply_initial_migration``
+ ``after`` to ``apply_tested_migration``

Closes #10 