### PR TITLE
version 1.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 We follow Semantic Versions since the `0.1.0` release.
 
+## Version 1.0.0
+
+### Breaking Changes
+
+- Rename following `Migrator` methods (#83):
+
+  + `before` to `apply_initial_migration`
+  + `after` to `apply_tested_migration`
+
+- Improves databases setup and teardown for migrations tests (#76)
+  Currently `Migrator.reset` uses `migrate` management command and all logic
+  related to migrations tests setup is moved to
+  `Migrator.apply_tested_migration`.
+
+### Bugfixes
+
+- Fixes `pre_migrate` and `post_migrate` signals muting (#87)
+- Adds missing `typing_extension` dependency (#86)
+
+### Misc
+
+- Refactor tests (#79)
+- Return `django` installed from `master` branch to testing matrix (#77)
+
 
 ## Version 0.3.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ style = "https://raw.githubusercontent.com/wemake-services/wemake-python-stylegu
 
 [tool.poetry]
 name = "django-test-migrations"
-version = "0.3.0"
+version = "1.0.0"
 description = "Test django schema and data migrations, including ordering"
 license = "MIT"
 


### PR DESCRIPTION
I decided to create PR with changelog and version bump, because I'm not sure if version `1.0.0` is proper one.
We are introducing many changes even incompatible ones so I feel like we need to bump major version, but from the other side it's something like `1.0.0-beta`.

Please let me know what do you think about this