### PR TITLE
Django 3.1 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
           'Django~=1.11.0',
           'Django~=2.2.0',
           'Django~=3.0.0',
-          'Django~=3.1rc1',
+          'Django~=3.1.0',
         ]
         continue-on-error: [false]
 

--- a/django_test_migrations/sql.py
+++ b/django_test_migrations/sql.py
@@ -80,7 +80,7 @@ def get_django_migrations_table_sequences(
 def get_sql_flush_with_sequences_for(
     connection: _Connection,
 ):
-    """Harmonizes sql_flush accross Django versions."""
+    """Harmonizes ``sql_flush`` accross Django versions."""
     if django.VERSION >= (3, 1):
         return partial(connection.ops.sql_flush, reset_sequences=True)
     return partial(
@@ -94,8 +94,8 @@ def get_execute_sql_flush_for(
 ) -> Callable[[List[str]], None]:
     """Return ``execute_sql_flush`` callable for given connection.
 
-    This function also harmonizes the signature of `execute_sql_flush`
-    to match Django 3.1 with `sql_list` as the only argument.
+    This function also harmonizes the signature of ``execute_sql_flush``
+    to match Django 3.1 with ``sql_list`` as the only argument.
 
     """
     if django.VERSION >= (3, 1):

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,5 +1,16 @@
 [[package]]
 category = "dev"
+description = "ASGI specs, helper code, and adapters"
+name = "asgiref"
+optional = false
+python-versions = ">=3.5"
+version = "3.2.10"
+
+[package.extras]
+tests = ["pytest", "pytest-asyncio"]
+
+[[package]]
+category = "dev"
 description = "Read/rewrite/write Python ASTs"
 name = "astor"
 optional = false
@@ -71,7 +82,7 @@ version = "7.1.2"
 [[package]]
 category = "dev"
 description = "Cross-platform colored terminal text."
-marker = "sys_platform == \"win32\" or platform_system == \"Windows\""
+marker = "platform_system == \"Windows\" or sys_platform == \"win32\""
 name = "colorama"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
@@ -115,12 +126,13 @@ category = "dev"
 description = "A high-level Python Web framework that encourages rapid development and clean, pragmatic design."
 name = "django"
 optional = false
-python-versions = ">=3.5"
-version = "2.2.13"
+python-versions = ">=3.6"
+version = "3.1"
 
 [package.dependencies]
+asgiref = ">=3.2.10,<3.3.0"
 pytz = "*"
-sqlparse = "*"
+sqlparse = ">=0.2.2"
 
 [package.extras]
 argon2 = ["argon2-cffi (>=16.1.0)"]
@@ -983,11 +995,15 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "d52f40676ddea0820d3ceb530452c500f0499aabe6f5a9045115e5037afc7a0c"
+content-hash = "139746282d2735035f04f1a9d0c89289c985a9f90b7f271b6be9e66e25925d85"
 lock-version = "1.0"
 python-versions = "^3.6"
 
 [metadata.files]
+asgiref = [
+    {file = "asgiref-3.2.10-py3-none-any.whl", hash = "sha256:9fc6fb5d39b8af147ba40765234fa822b39818b12cc80b35ad9b0cef3a476aed"},
+    {file = "asgiref-3.2.10.tar.gz", hash = "sha256:7e51911ee147dd685c3c8b805c0ad0cb58d360987b56953878f8c06d2d1c6f1a"},
+]
 astor = [
     {file = "astor-0.8.1-py2.py3-none-any.whl", hash = "sha256:070a54e890cefb5b3739d19f30f5a5ec840ffc9c50ffa7d23cc9fc1a38ebbfc5"},
     {file = "astor-0.8.1.tar.gz", hash = "sha256:6a6effda93f4e1ce9f618779b2dd1d9d84f1e32812c23a29b3fff6fd7f63fa5e"},
@@ -1062,8 +1078,8 @@ dictdiffer = [
     {file = "dictdiffer-0.8.1.tar.gz", hash = "sha256:1adec0d67cdf6166bda96ae2934ddb5e54433998ceab63c984574d187cc563d2"},
 ]
 django = [
-    {file = "Django-2.2.13-py3-none-any.whl", hash = "sha256:e8fe3c2b2212dce6126becab7a693157f1a441a07b62ec994c046c76af5bb66d"},
-    {file = "Django-2.2.13.tar.gz", hash = "sha256:84f370f6acedbe1f3c41e1a02de44ac206efda3355e427139ecb785b5f596d80"},
+    {file = "Django-3.1-py3-none-any.whl", hash = "sha256:1a63f5bb6ff4d7c42f62a519edc2adbb37f9b78068a5a862beff858b68e3dc8b"},
+    {file = "Django-3.1.tar.gz", hash = "sha256:2d390268a13c655c97e0e2ede9d117007996db692c1bb93eabebd4fb7ea7012b"},
 ]
 docutils = [
     {file = "docutils-0.16-py2.py3-none-any.whl", hash = "sha256:0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ python = "^3.6"
 typing_extensions = "^3.7.4"
 
 [tool.poetry.dev-dependencies]
-django = "^2.2"
+django = "^3.1"
 
 mypy = "^0.782"
 wemake-python-styleguide = "^0.14"

--- a/tests/test_sql/test_drop_models_table.py
+++ b/tests/test_sql/test_drop_models_table.py
@@ -22,5 +22,8 @@ def test_drop_models_table_table_detected(mocker):
     ]
     connections_mock = mocker.patch('django.db.connections._connections')
     connections_mock.test = testing_connection_mock
+    execute_sql_flush_mock = mocker.patch(
+        'django_test_migrations.sql.get_execute_sql_flush_for',
+    )
     sql.drop_models_tables(TESTING_DATABASE_NAME)
-    testing_connection_mock.ops.execute_sql_flush.assert_called_once()
+    execute_sql_flush_mock(testing_connection_mock).assert_called_once()

--- a/tests/test_sql/test_flush_utils.py
+++ b/tests/test_sql/test_flush_utils.py
@@ -1,8 +1,19 @@
+from contextlib import contextmanager
 from functools import partial
 
+import django
 from django.core.management.color import Style
 
 from django_test_migrations import sql
+
+
+@contextmanager
+def simulate_django_version(version):
+    """Context manager that changes the django VERSION to test compatibility."""
+    current_django_version = django.VERSION
+    django.VERSION = version
+    yield version
+    django.VERSION = current_django_version
 
 
 def test_flush_django_migrations_table(mocker):
@@ -13,35 +24,94 @@ def test_flush_django_migrations_table(mocker):
     connections_mock = mocker.patch('django.db.connections._connections')
     connections_mock.test = testing_connection_mock
     sql.flush_django_migrations_table('test', style)
-    testing_connection_mock.ops.sql_flush.assert_called_once_with(
-        style,
-        [sql.DJANGO_MIGRATIONS_TABLE_NAME],
-        [],
-        allow_cascade=False,
-    )
-    testing_connection_mock.ops.execute_sql_flush.assert_called_once_with(
-        'test',
-        mocker.ANY,
-    )
+    if django.VERSION >= (3, 1):
+        testing_connection_mock.ops.sql_flush.assert_called_once_with(
+            style,
+            [sql.DJANGO_MIGRATIONS_TABLE_NAME],
+            reset_sequences=True,
+            allow_cascade=False,
+        )
+        testing_connection_mock.ops.execute_sql_flush.assert_called_once_with(
+            mocker.ANY,
+        )
+    elif django.VERSION >= (2, 0):
+        testing_connection_mock.ops.sql_flush.assert_called_once_with(
+            style,
+            [sql.DJANGO_MIGRATIONS_TABLE_NAME],
+            sequences=[],
+            allow_cascade=False,
+        )
+        testing_connection_mock.ops.execute_sql_flush.assert_called_once_with(
+            mocker.ANY,
+            mocker.ANY,
+        )
+    else:
+        testing_connection_mock.ops.sql_flush.assert_called_once_with(
+            style,
+            [sql.DJANGO_MIGRATIONS_TABLE_NAME],
+            sequences=[],
+            allow_cascade=False,
+        )
 
 
-def test_get_execute_sql_flush_for_method_present(mocker):
-    """Ensure connections.ops method returned when it is already present."""
-    connection_mock = mocker.Mock()
-    connection_mock.ops.execute_sql_flush = _fake_execute_sql_flush
-    execute_sql_flush = sql.get_execute_sql_flush_for(connection_mock)
-    assert execute_sql_flush == _fake_execute_sql_flush
+class TestGetSqlFlushWithSequences(object):
+    """Ensure we call `sql_flush` rightly accross Django versions."""
+
+    def test_for_django31(self, mocker):
+        """Ensure we are calling sql_flush with `reset_sequences`."""
+        connection_mock = mocker.Mock()
+        connection_mock.ops.sql_flush = _fake_sql_flush
+        with simulate_django_version((3, 1, 'final', 0)):
+            sql_flush = sql.get_sql_flush_with_sequences_for(connection_mock)
+        assert sql_flush.func == _fake_sql_flush
+        assert sql_flush.keywords == {'reset_sequences': True}
+
+    def test_for_django22(self, mocker):
+        """Ensure we are calling sql_flush with the positionnal `sequences`."""
+        connection_mock = mocker.MagicMock()
+        connection_mock.ops.sql_flush.return_value = _fake_sql_flush
+        connection_mock.introspection.get_sequences.return_value = []
+        with simulate_django_version((2, 0, 'final', 0)):
+            sql_flush = sql.get_sql_flush_with_sequences_for(connection_mock)
+        assert sql_flush.func == connection_mock.ops.sql_flush
+        assert sql_flush.keywords == {'sequences': []}
 
 
-def test_get_execute_sql_flush_for_method_missing(mocker):
-    """Ensure custom function is returned when connection.ops miss methods."""
-    connection_mock = mocker.Mock()
-    del connection_mock.ops.execute_sql_flush  # noqa: WPS420
-    execute_sql_flush = sql.get_execute_sql_flush_for(connection_mock)
-    assert isinstance(execute_sql_flush, partial)
-    assert execute_sql_flush.func == sql.execute_sql_flush
-    assert execute_sql_flush.args[0] == connection_mock
+class TestGetExecuteSqlFlush(object):
+    """Ensure we call `execute_sql_flush` rightly accross Django versions."""
+
+    def test_for_django31(self, mocker):
+        """Ensure we are getting execute_sql_flush directly."""
+        connection_mock = mocker.Mock()
+        connection_mock.ops.execute_sql_flush = _fake_execute_sql_flush
+        with simulate_django_version((3, 1, 'final', 0)):
+            execute_sql_flush = sql.get_execute_sql_flush_for(connection_mock)
+        assert execute_sql_flush == _fake_execute_sql_flush
+
+    def test_for_django20(self, mocker):
+        """Ensure we call execute_sql_flush with the database name."""
+        connection_mock = mocker.Mock()
+        connection_mock.alias = 'test'
+        connection_mock.ops.execute_sql_flush = _fake_execute_sql_flush
+        with simulate_django_version((2, 0, 'final', 0)):
+            execute_sql_flush = sql.get_execute_sql_flush_for(connection_mock)
+        assert execute_sql_flush.func == _fake_execute_sql_flush
+        assert execute_sql_flush.args[0] == 'test'
+
+    def test_for_django1_11(self, mocker):
+        """Ensure custom function is returned."""
+        connection_mock = mocker.Mock()
+
+        with simulate_django_version((1, 11, 'final', 0)):
+            execute_sql_flush = sql.get_execute_sql_flush_for(connection_mock)
+        assert isinstance(execute_sql_flush, partial)
+        assert execute_sql_flush.func == sql.execute_sql_flush
+        assert execute_sql_flush.args[0] == connection_mock
 
 
-def _fake_execute_sql_flush(using, sql_list):
+def _fake_execute_sql_flush(sql_list):
+    return None
+
+
+def _fake_sql_flush():
     return None

--- a/tests/test_sql/test_flush_utils.py
+++ b/tests/test_sql/test_flush_utils.py
@@ -9,7 +9,7 @@ from django_test_migrations import sql
 
 @contextmanager
 def simulate_django_version(version):
-    """Context manager that changes the django VERSION to test compatibility."""
+    """Context manager that changes ``django.VERSION`` to test compatibility."""
     current_django_version = django.VERSION
     django.VERSION = version
     yield version
@@ -55,10 +55,10 @@ def test_flush_django_migrations_table(mocker):
 
 
 class TestGetSqlFlushWithSequences(object):
-    """Ensure we call `sql_flush` rightly accross Django versions."""
+    """Ensure we call ``sql_flush`` rightly accross Django versions."""
 
     def test_for_django31(self, mocker):
-        """Ensure we are calling sql_flush with `reset_sequences`."""
+        """Ensure we call ``sql_flush`` with ``reset_sequences``."""
         connection_mock = mocker.Mock()
         connection_mock.ops.sql_flush = _fake_sql_flush
         with simulate_django_version((3, 1, 'final', 0)):
@@ -67,7 +67,7 @@ class TestGetSqlFlushWithSequences(object):
         assert sql_flush.keywords == {'reset_sequences': True}
 
     def test_for_django22(self, mocker):
-        """Ensure we are calling sql_flush with the positionnal `sequences`."""
+        """Ensure we call ``sql_flush`` with the positionnal ``sequences``."""
         connection_mock = mocker.MagicMock()
         connection_mock.ops.sql_flush.return_value = _fake_sql_flush
         connection_mock.introspection.get_sequences.return_value = []
@@ -78,10 +78,10 @@ class TestGetSqlFlushWithSequences(object):
 
 
 class TestGetExecuteSqlFlush(object):
-    """Ensure we call `execute_sql_flush` rightly accross Django versions."""
+    """Ensure we call ``execute_sql_flush`` rightly accross Django versions."""
 
     def test_for_django31(self, mocker):
-        """Ensure we are getting execute_sql_flush directly."""
+        """Ensure we are getting ``execute_sql_flush`` directly."""
         connection_mock = mocker.Mock()
         connection_mock.ops.execute_sql_flush = _fake_execute_sql_flush
         with simulate_django_version((3, 1, 'final', 0)):
@@ -89,7 +89,7 @@ class TestGetExecuteSqlFlush(object):
         assert execute_sql_flush == _fake_execute_sql_flush
 
     def test_for_django20(self, mocker):
-        """Ensure we call execute_sql_flush with the database name."""
+        """Ensure we call ``execute_sql_flush`` with the database name."""
         connection_mock = mocker.Mock()
         connection_mock.alias = 'test'
         connection_mock.ops.execute_sql_flush = _fake_execute_sql_flush


### PR DESCRIPTION
Fixes #117 

Those changes should support all the Django versions currently officially supported. I switched from feature detection to Django version cases because it becomes IMO a bit hacky to do feature detection on the shape of the function. 