### PR TITLE
run tests against MySQL and PostgreSQL DB engines

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
           'Django~=3.0.0',
           'Django~=3.1.0',
         ]
-        services: ['']
+        docker-compose-services: ['']
         additional-dependencies: ['']
         continue-on-error: [false]
 
@@ -32,7 +32,7 @@ jobs:
             continue-on-error: true
           - python-version: 3.8
             django-version: 'Django~=3.0.0'
-            services: postgresql-db
+            docker-compose-services: postgresql-db
             additional-dependencies: psycopg2
             env:
               DJANGO_DATABASE_ENGINE: django.db.backends.postgresql
@@ -40,7 +40,7 @@ jobs:
             continue-on-error: false
           - python-version: 3.8
             django-version: 'Django~=3.0.0'
-            services: mysql-db
+            docker-compose-services: mysql-db
             additional-dependencies: mysqlclient
             env:
               DJANGO_DATABASE_ENGINE: django.db.backends.mysql
@@ -76,10 +76,10 @@ jobs:
           ${{ matrix.additional-dependencies }}
 
       - name: Pull and build docker-compose services
-        if: ${{ matrix.services }}
+        if: ${{ matrix.docker-compose-services }}
         run: |
-          docker-compose pull ${{ matrix.services }}
-          docker-compose up --detach ${{ matrix.services }}
+          docker-compose pull ${{ matrix.docker-compose-services }}
+          docker-compose up --detach ${{ matrix.docker-compose-services }}
           # TODO: wait with some predefined timeout for services
 
       - name: "Run checks for python ${{ matrix.python-version }} and django ${{ matrix.django-version }}"
@@ -93,5 +93,5 @@ jobs:
           file: ./coverage.xml
 
       - name: Stop docker-compose services
-        if: ${{ always() && matrix.services }}
+        if: ${{ always() && matrix.docker-compose-services }}
         run: docker-compose down || true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,18 @@
 ---
 name: test
-on: [push, pull_request]
+'on': [push, pull_request]
 
 jobs:
   build:
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.continue-on-error }}
+    env:
+      DJANGO_DATABASE_ENGINE: "${{ matrix.env.DJANGO_DATABASE_ENGINE || 'django.db.backends.sqlite3' }}"
+      DJANGO_DATABASE_USER: django
+      DJANGO_DATABASE_PASSWORD: passwd123
+      DJANGO_DATABASE_NAME: db
+      DJANGO_DATABASE_HOST: 127.0.0.1
+      DJANGO_DATABASE_PORT: "${{ matrix.env.DJANGO_DATABASE_PORT }}"
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8]
@@ -15,12 +22,30 @@ jobs:
           'Django~=3.0.0',
           'Django~=3.1.0',
         ]
+        services: ['']
+        additional-dependencies: ['']
         continue-on-error: [false]
 
         include:
           - python-version: 3.8
             django-version: 'https://github.com/django/django/archive/master.zip'
             continue-on-error: true
+          - python-version: 3.8
+            django-version: 'Django~=3.0.0'
+            services: postgresql-db
+            additional-dependencies: psycopg2
+            env:
+              DJANGO_DATABASE_ENGINE: django.db.backends.postgresql
+              DJANGO_DATABASE_PORT: 5432
+            continue-on-error: false
+          - python-version: 3.8
+            django-version: 'Django~=3.0.0'
+            services: mysql-db
+            additional-dependencies: mysqlclient
+            env:
+              DJANGO_DATABASE_ENGINE: django.db.backends.mysql
+              DJANGO_DATABASE_PORT: 3306
+            continue-on-error: false
 
     steps:
       - uses: actions/checkout@v2
@@ -39,12 +64,23 @@ jobs:
         with:
           path: .venv
           key: venv-${{ matrix.python-version }}-${{ matrix.django-version }}-${{ hashFiles('poetry.lock') }}
+
       - name: Install dependencies
         run: |
           source "$HOME/.poetry/env"
           poetry config virtualenvs.in-project true
           poetry install
-          pip install -U "${{ matrix.django-version }}"
+          poetry run pip install \
+            --upgrade \
+          "${{ matrix.django-version }}" \
+          ${{ matrix.additional-dependencies }}
+
+      - name: Pull and build docker-compose services
+        if: ${{ matrix.services }}
+        run: |
+          docker-compose pull ${{ matrix.services }}
+          docker-compose up --detach ${{ matrix.services }}
+          # TODO: wait with some predefined timeout for services
 
       - name: "Run checks for python ${{ matrix.python-version }} and django ${{ matrix.django-version }}"
         run: |
@@ -55,3 +91,7 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           file: ./coverage.xml
+
+      - name: Stop docker-compose services
+        if: ${{ always() && matrix.services }}
+        run: docker-compose down || true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
       DJANGO_DATABASE_NAME: db
       DJANGO_DATABASE_HOST: 127.0.0.1
       DJANGO_DATABASE_PORT: "${{ matrix.env.DJANGO_DATABASE_PORT }}"
+      DOCKERIZE_VERSION: v0.6.1
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8]
@@ -80,7 +81,19 @@ jobs:
         run: |
           docker-compose pull ${{ matrix.docker-compose-services }}
           docker-compose up --detach ${{ matrix.docker-compose-services }}
-          # TODO: wait with some predefined timeout for services
+
+      - name: Wait for docker-compose services
+        if: ${{ matrix.docker-compose-services }}
+        run: |
+          wget \
+            https://github.com/jwilder/dockerize/releases/download/${DOCKERIZE_VERSION}/dockerize-linux-amd64-${DOCKERIZE_VERSION}.tar.gz \
+          && tar -C . -xzvf dockerize-linux-amd64-${DOCKERIZE_VERSION}.tar.gz \
+          && rm dockerize-linux-amd64-${DOCKERIZE_VERSION}.tar.gz \
+          && chmod +x dockerize
+          ./dockerize \
+            -wait "tcp://localhost:${{ matrix.env.DJANGO_DATABASE_PORT }}" \
+            -wait-retry-interval "1s" \
+            -timeout "30s"
 
       - name: "Run checks for python ${{ matrix.python-version }} and django ${{ matrix.django-version }}"
         run: |

--- a/django_test_app/django_test_app/settings.py
+++ b/django_test_app/django_test_app/settings.py
@@ -84,8 +84,18 @@ WSGI_APPLICATION = 'django_test_app.wsgi.application'
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+        'ENGINE': os.environ.get(
+            'DJANGO_DATABASE_ENGINE',
+            default='django.db.backends.sqlite3',
+        ),
+        'USER': os.environ.get('DJANGO_DATABASE_USER', default=''),
+        'PASSWORD': os.environ.get('DJANGO_DATABASE_PASSWORD', default=''),
+        'NAME': os.environ.get(
+            'DJANGO_DATABASE_NAME',
+            default=os.path.join(BASE_DIR, 'db.sqlite3'),
+        ),
+        'PORT': os.environ.get('DJANGO_DATABASE_PORT', default=''),
+        'HOST': os.environ.get('DJANGO_DATABASE_HOST', default=''),
     },
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+---
+version: '3.8'
+
+services:
+  postgresql-db:
+    image: postgres:12
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_USER=django
+      - POSTGRES_PASSWORD=passwd123
+      - POSTGRES_DB=db
+
+  mysql-db:
+    image: mysql:8
+    ports:
+      - "3306:3306"
+    environment:
+      - MYSQL_USER=django
+      - MYSQL_PASSWORD=passwd123
+      # NOTE: MySQL container entrypoint gives user `${MYSQL_USER}` access
+      # only to `${MYSQL_DATABASE}` database, so we are setting
+      # `${MYSQL_DATABASE}` to Django default test database's name to avoid
+      # overriding `ENTRYPOINT` or `CMD`.
+      - MYSQL_DATABASE=test_db
+      - MYSQL_ROOT_PASSWORD=superpasswd123
+    command: --default-authentication-plugin=mysql_native_password


### PR DESCRIPTION
Closes: #107 

Things nice to have (now or in future PRs):

+ load `.env` file in `django_test_app/django_test_app/settings.py` (usually, I'm using [django-environ](https://github.com/joke2k/django-environ/) for this), to make local development easier. Alternatively, we can add some service to `docker-compose.yml` that will make local development even easier.
+ use `network: host` instead of `ports` binding, so it will be easier to run services locally (this will probably require to use `docker-compose.ci.yml` for CI and `docker-compose.override.yml` for local development)
+ wait with some timeout for database services
+ consider installing `wheel` to avoid using legacy `setup.py install` when installing additional dependencies