### PR TITLE
Mute migrate signals when calling apply_*_migration

### DIFF
--- a/django_test_migrations/contrib/pytest_plugin.py
+++ b/django_test_migrations/contrib/pytest_plugin.py
@@ -2,7 +2,6 @@ from typing import Optional
 
 import pytest
 from django.db import DEFAULT_DB_ALIAS
-from django.db.models.signals import post_migrate, pre_migrate
 
 
 @pytest.fixture()
@@ -46,20 +45,7 @@ def migrator_factory(request, transactional_db, django_db_use_migrations):
 
 
 @pytest.fixture()
-def _mute_migration_signals():
-    restore_pre, pre_migrate.receivers = (  # noqa: WPS414
-        pre_migrate.receivers, [],
-    )
-    restore_post, post_migrate.receivers = (  # noqa: WPS414
-        post_migrate.receivers, [],
-    )
-    yield
-    pre_migrate.receivers = restore_pre
-    post_migrate.receivers = restore_post
-
-
-@pytest.fixture()
-def migrator(_mute_migration_signals, migrator_factory):  # noqa: WPS442
+def migrator(migrator_factory):  # noqa: WPS442
     """
     Useful alias for ``'default'`` database in ``django``.
 

--- a/django_test_migrations/contrib/unittest_case.py
+++ b/django_test_migrations/contrib/unittest_case.py
@@ -47,6 +47,8 @@ class MigratorTestCase(TransactionTestCase):
 
     def tearDown(self) -> None:
         """Used to clean mess up after each test."""
+        pre_migrate.receivers = self._pre_migrate_receivers
+        post_migrate.receivers = self._post_migrate_receivers
         self._migrator.reset()
         super().tearDown()
 
@@ -58,8 +60,3 @@ class MigratorTestCase(TransactionTestCase):
             post_migrate.receivers, [],
         )
         super()._pre_setup()
-
-    def _post_teardown(self):
-        super()._post_teardown()
-        pre_migrate.receivers = self._pre_migrate_receivers
-        post_migrate.receivers = self._post_migrate_receivers

--- a/django_test_migrations/migrator.py
+++ b/django_test_migrations/migrator.py
@@ -71,6 +71,7 @@ class Migrator(object):
 
         Notably, signals are not muted here to avoid
         https://github.com/wemake-services/django-test-migrations/issues/128
+
         """
         call_command('migrate', verbosity=0, database=self._database)
 

--- a/django_test_migrations/signals.py
+++ b/django_test_migrations/signals.py
@@ -5,6 +5,7 @@ from django.db.models.signals import post_migrate, pre_migrate
 
 @contextmanager
 def mute_migrate_signals():
+    """Context manager to mute migration-related signals."""
     pre_migrate_receivers = pre_migrate.receivers
     post_migrate_receivers = post_migrate.receivers
     pre_migrate.receivers = post_migrate.receivers = []

--- a/django_test_migrations/signals.py
+++ b/django_test_migrations/signals.py
@@ -8,7 +8,8 @@ def mute_migrate_signals():
     """Context manager to mute migration-related signals."""
     pre_migrate_receivers = pre_migrate.receivers
     post_migrate_receivers = post_migrate.receivers
-    pre_migrate.receivers = post_migrate.receivers = []
+    pre_migrate.receivers = []
+    post_migrate.receivers = []
     yield pre_migrate_receivers, post_migrate_receivers
     pre_migrate.receivers = pre_migrate_receivers
     post_migrate.receivers = post_migrate_receivers

--- a/django_test_migrations/signals.py
+++ b/django_test_migrations/signals.py
@@ -1,0 +1,13 @@
+from contextlib import contextmanager
+
+from django.db.models.signals import post_migrate, pre_migrate
+
+
+@contextmanager
+def mute_migrate_signals():
+    pre_migrate_receivers = pre_migrate.receivers
+    post_migrate_receivers = post_migrate.receivers
+    pre_migrate.receivers = post_migrate.receivers = []
+    yield pre_migrate_receivers, post_migrate_receivers
+    pre_migrate.receivers = pre_migrate_receivers
+    post_migrate.receivers = post_migrate_receivers

--- a/tests/test_contrib/test_unittest_case/test_signals.py
+++ b/tests/test_contrib/test_unittest_case/test_signals.py
@@ -17,12 +17,10 @@ class TestSignalMuting(MigratorTestCase):
     def test_pre_migrate_muted(self):
         """Ensure ``pre_migrate`` signal has been muted."""
         assert not pre_migrate.receivers
-        assert self._pre_migrate_receivers
 
     def test_post_migrate_muted(self):
         """Ensure ``post_migrate`` signal has been muted."""
         assert not post_migrate.receivers
-        assert self._post_migrate_receivers
 
 
 class TestSignalConnectInTest(MigratorTestCase):


### PR DESCRIPTION
This moves signal handling into the Migrator class. As a desired side effect, Migrator.reset is called with unmuted signals.

Fixes https://github.com/wemake-services/django-test-migrations/issues/128