### PR TITLE
disable foreign key checks when dropping tables on MySQL

### DIFF
--- a/django_test_migrations/sql.py
+++ b/django_test_migrations/sql.py
@@ -30,6 +30,12 @@ def drop_models_tables(
         for table in tables
     ]
     if sql_drop_tables:
+        if connection.vendor == 'mysql':
+            sql_drop_tables = [
+                'SET FOREIGN_KEY_CHECKS = 0;',
+                *sql_drop_tables,
+                'SET FOREIGN_KEY_CHECKS = 1;',
+            ]
         get_execute_sql_flush_for(connection)(sql_drop_tables)
 
 


### PR DESCRIPTION
Closes #122 

This is a quick solution for problems with `MySQL` and `drop_models_tables`. It's not an ideal solution, better one (but also with more time consuming and verbose implementation) is described in https://github.com/wemake-services/django-test-migrations/issues/122#issuecomment-701208857 

On branch [`test-mysql-drop-table-fix`](https://github.com/wemake-services/django-test-migrations/tree/test-mysql-drop-table-fix) you can find this branch merged to branch from https://github.com/wemake-services/django-test-migrations/pull/129, where all tests are running against `MySQL` (started in a container), so we can see this solves #122  - https://github.com/wemake-services/django-test-migrations/actions/runs/389114796