### PR TITLE
Support python 3.8

### DIFF
--- a/django_test_migrations/checks/autonames.py
+++ b/django_test_migrations/checks/autonames.py
@@ -3,7 +3,8 @@ from typing import FrozenSet, List, Tuple
 
 from django.conf import settings
 from django.core.checks import CheckMessage, Warning
-from typing_extensions import Final
+
+from django_test_migrations.typing_compat import Final
 
 _IgnoreAppSpec = FrozenSet[str]
 

--- a/django_test_migrations/checks/database_configuration.py
+++ b/django_test_migrations/checks/database_configuration.py
@@ -1,8 +1,7 @@
-from typing_extensions import Final
-
 from django_test_migrations.db.checks.statement_timeout import (
     check_statement_timeout_setting,
 )
+from django_test_migrations.typing_compat import Final
 
 #: We use this value as a unique identifier of databases related check.
 CHECK_NAME: Final = 'django_test_migrations.checks.database_configuration'

--- a/django_test_migrations/constants.py
+++ b/django_test_migrations/constants.py
@@ -1,4 +1,5 @@
-from typing_extensions import Final
+from django_test_migrations.typing_compat import Final
+
 
 #: marker/tag indicating that marked test is a Django's migration test
 MIGRATION_TEST_MARKER: Final = 'migration_test'

--- a/django_test_migrations/contrib/django_checks.py
+++ b/django_test_migrations/contrib/django_checks.py
@@ -1,8 +1,8 @@
 from django.apps import AppConfig
 from django.core import checks
-from typing_extensions import final
 
 from django_test_migrations.checks import autonames, database_configuration
+from django_test_migrations.typing_compat import final
 
 
 @final

--- a/django_test_migrations/db/backends/mysql/configuration.py
+++ b/django_test_migrations/db/backends/mysql/configuration.py
@@ -1,9 +1,8 @@
-from typing_extensions import final
-
 from django_test_migrations.db.backends.base.configuration import (
     BaseDatabaseConfiguration,
 )
 from django_test_migrations.types import DatabaseSettingValue
+from django_test_migrations.typing_compat import final
 
 
 @final

--- a/django_test_migrations/db/backends/postgresql/configuration.py
+++ b/django_test_migrations/db/backends/postgresql/configuration.py
@@ -1,9 +1,8 @@
-from typing_extensions import final
-
 from django_test_migrations.db.backends.base.configuration import (
     BaseDatabaseConfiguration,
 )
 from django_test_migrations.types import DatabaseSettingValue
+from django_test_migrations.typing_compat import final
 
 
 @final

--- a/django_test_migrations/db/backends/registry.py
+++ b/django_test_migrations/db/backends/registry.py
@@ -1,11 +1,11 @@
 from typing import MutableMapping, Type
 
-from typing_extensions import TYPE_CHECKING
 
 from django_test_migrations.db.backends.exceptions import (
     DatabaseConfigurationNotFound,
 )
 from django_test_migrations.types import AnyConnection
+from django_test_migrations.typing_compat import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from django_test_migrations.db.backends.base.configuration import (

--- a/django_test_migrations/db/checks/statement_timeout.py
+++ b/django_test_migrations/db/checks/statement_timeout.py
@@ -3,7 +3,6 @@ from typing import List
 
 from django.core.checks import CheckMessage, Warning
 from django.db import connections
-from typing_extensions import Final
 
 from django_test_migrations.db.backends import exceptions, registry
 from django_test_migrations.db.backends.base.configuration import (
@@ -11,6 +10,8 @@ from django_test_migrations.db.backends.base.configuration import (
 )
 from django_test_migrations.logic.datetime import timedelta_to_miliseconds
 from django_test_migrations.types import AnyConnection
+from django_test_migrations.typing_compat import Final
+
 
 #: We use this value as a unique identifier of databases related check.
 CHECK_NAME: Final = 'django_test_migrations.checks.database_configuration'

--- a/django_test_migrations/sql.py
+++ b/django_test_migrations/sql.py
@@ -4,9 +4,9 @@ from typing import Callable, Dict, List, Optional
 import django
 from django.core.management.color import Style, no_style
 from django.db import connections, transaction
-from typing_extensions import Final
 
 from django_test_migrations.types import AnyConnection
+from django_test_migrations.typing_compat import Final
 
 DJANGO_MIGRATIONS_TABLE_NAME: Final = 'django_migrations'
 

--- a/django_test_migrations/typing_compat.py
+++ b/django_test_migrations/typing_compat.py
@@ -1,0 +1,4 @@
+try:
+    from typing import Final, final, TYPE_CHECKING
+except ImportError:
+    from typing_extensions import Final, final, TYPE_CHECKING

--- a/tests/test_contrib/test_pytest_plugin/test_signals.py
+++ b/tests/test_contrib/test_pytest_plugin/test_signals.py
@@ -3,9 +3,10 @@ from django.apps import apps
 from django.core.management import call_command
 from django.db import DEFAULT_DB_ALIAS
 from django.db.models.signals import post_migrate, pre_migrate
-from typing_extensions import Final
 
+from django_test_migrations.typing_compat import Final
 from django_test_migrations.signals import mute_migrate_signals
+
 
 # value for ``dispatch_uid`` is needed to disconnect signal receiver
 # registered for testing purposes to which we do not have any reference


### PR DESCRIPTION
Since `typing_extensions` has the following marker: `python_version < '3.8'` it wont be installed (at least with pipenv) on python 3.8. This makes this library incompatible with python 3.8 and above.