### PR TITLE
docs: Fix a few typos

### DIFF
--- a/django_test_migrations/logic/datetime.py
+++ b/django_test_migrations/logic/datetime.py
@@ -1,6 +1,6 @@
 import datetime
 
 
-def timedelta_to_miliseconds(timedelta: datetime.timedelta) -> int:
-    """Convert ``timedelta`` object to miliseconds."""
+def timedelta_to_milliseconds(timedelta: datetime.timedelta) -> int:
+    """Convert ``timedelta`` object to milliseconds."""
     return int(timedelta.total_seconds() * 1000)

--- a/django_test_migrations/sql.py
+++ b/django_test_migrations/sql.py
@@ -44,7 +44,7 @@ def flush_django_migrations_table(
 ) -> None:
     """Flush `django_migrations` table.
 
-    Ensures compability with all supported Django versions.
+    Ensures compatibility with all supported Django versions.
     `django_migrations` is not "regular" Django model, so its not returned
     by ``ConnectionRouter.get_migratable_models`` which is used e.g. to
     implement sequences reset in ``Django==1.11``.

--- a/tests/test_contrib/test_unittest_case/test_unittest_case.py
+++ b/tests/test_contrib/test_unittest_case/test_unittest_case.py
@@ -42,6 +42,6 @@ class TestBackwardMigration(MigratorTestCase):
 
 
 def test_migration_test_marker_tag():
-    """Ensure ``MigratorTestCase`` sublasses are properly tagged."""
+    """Ensure ``MigratorTestCase`` subclasses are properly tagged."""
     assert MIGRATION_TEST_MARKER in TestDirectMigration.tags
     assert MIGRATION_TEST_MARKER in TestBackwardMigration.tags

--- a/tests/test_db/test_backends/test_registry.py
+++ b/tests/test_db/test_backends/test_registry.py
@@ -22,7 +22,7 @@ def test_abc_subclasses_are_not_registered():
     registered.
     """
     vendor = 'abstract_subclass'
-    # creates abstract subclasss
+    # creates abstract subclass
     type('DatabaseConfiguration', (BaseDatabaseConfiguration,), {
         'vendor': vendor,
     })

--- a/tests/test_sql/test_flush_utils.py
+++ b/tests/test_sql/test_flush_utils.py
@@ -95,7 +95,7 @@ class TestGetSqlFlushWithSequences(object):
         assert sql_flush.keywords == {'reset_sequences': True}
 
     def test_for_django22(self, mocker):
-        """Ensure we call ``sql_flush`` with the positionnal ``sequences``."""
+        """Ensure we call ``sql_flush`` with the positional ``sequences``."""
         connection_mock = mocker.MagicMock()
         connection_mock.ops.sql_flush.return_value = _fake_sql_flush
         connection_mock.introspection.get_sequences.return_value = []


### PR DESCRIPTION
There are small typos in:
- django_test_migrations/logic/datetime.py
- django_test_migrations/sql.py
- tests/test_contrib/test_unittest_case/test_unittest_case.py
- tests/test_db/test_backends/test_registry.py
- tests/test_sql/test_flush_utils.py

Fixes:
- Should read `subclasses` rather than `sublasses`.
- Should read `subclass` rather than `subclasss`.
- Should read `positional` rather than `positionnal`.
- Should read `milliseconds` rather than `miliseconds`.
- Should read `compatibility` rather than `compability`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md