### PR TITLE
fix: properly handle statement_timeout based on mysql version

### DIFF
--- a/.dev/scripts/ci-mysql-setup-integration-tests.sh
+++ b/.dev/scripts/ci-mysql-setup-integration-tests.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+set -o xtrace
+
+_SETUP_SCRIPT="$(cat << EOM
+  CREATE DATABASE IF NOT EXISTS db;
+  GRANT ALL PRIVILEGES ON db.* TO django;
+  FLUSH PRIVILEGES;
+EOM
+)"
+mysql \
+  --host="${DJANGO_DATABASE_HOST}" \
+  --port="${DJANGO_DATABASE_PORT}" \
+  --user="root" \
+  --password="superpasswd123" \
+  --execute="${_SETUP_SCRIPT}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,9 @@ jobs:
           - 'Django~=4.2.0'
         docker-compose-services: ['']
         additional-dependencies: ['']
+        env: [{}]
         continue-on-error: [false]
+        integration-test-setup-script: ['']
 
         include:
           - python-version: '3.11'
@@ -75,6 +77,19 @@ jobs:
               DJANGO_DATABASE_ENGINE: 'django.db.backends.mysql'
               DJANGO_DATABASE_PORT: 3306
             continue-on-error: false
+            integration-test-setup-script: |
+              _SETUP_SCRIPT="$(cat << EOM
+                CREATE DATABASE IF NOT EXISTS db;
+                GRANT ALL PRIVILEGES ON db.* TO django;
+                FLUSH PRIVILEGES;
+              EOM
+              )"
+              mysql \
+                --host="${DJANGO_DATABASE_HOST}" \
+                --port="${DJANGO_DATABASE_PORT}" \
+                --user="root" \
+                --password="superpasswd123" \
+                --execute="${_SETUP_SCRIPT}"
           - python-version: '3.10'
             django-version: 'Django~=4.1.0'
             docker-compose-services: maria-db
@@ -83,6 +98,19 @@ jobs:
               DJANGO_DATABASE_ENGINE: 'django.db.backends.mysql'
               DJANGO_DATABASE_PORT: 3307
             continue-on-error: false
+            integration-test-setup-script: |
+              _SETUP_SCRIPT="$(cat << EOM
+                CREATE DATABASE IF NOT EXISTS db;
+                GRANT ALL PRIVILEGES ON db.* TO django;
+                FLUSH PRIVILEGES;
+              EOM
+              )"
+              mysql \
+                --host="${DJANGO_DATABASE_HOST}" \
+                --port="${DJANGO_DATABASE_PORT}" \
+                --user="root" \
+                --password="superpasswd123" \
+                --execute="${_SETUP_SCRIPT}"
 
     steps:
       - uses: actions/checkout@v3
@@ -130,6 +158,21 @@ jobs:
 
       - name: "Run checks for python ${{ matrix.python-version }} and django ${{ matrix.django-version }}"
         run: make test
+
+      - name: >-
+          Run integration tests for python ${{ matrix.python-version }}
+          and django ${{ matrix.django-version }} using
+          ${{ matrix.docker-compose-services }}
+        if: ${{ matrix.docker-compose-services }}
+        run: |
+          echo '${{ matrix.integration-test-setup-script }}' > setup-test.sh
+          if [ -f setup-test.sh  ]; then
+            bash setup-test.sh
+          fi
+          CHECK_OUTPUT="$(poetry run python django_test_app/manage.py check 2>&1 || true)"
+          echo "${CHECK_OUTPUT}"
+          echo "${CHECK_OUTPUT}" \
+          | grep --quiet --extended-regexp '^System check identified 4 issues'
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,19 +77,8 @@ jobs:
               DJANGO_DATABASE_ENGINE: 'django.db.backends.mysql'
               DJANGO_DATABASE_PORT: 3306
             continue-on-error: false
-            integration-test-setup-script: |
-              _SETUP_SCRIPT="$(cat << EOM
-                CREATE DATABASE IF NOT EXISTS db;
-                GRANT ALL PRIVILEGES ON db.* TO django;
-                FLUSH PRIVILEGES;
-              EOM
-              )"
-              mysql \
-                --host="${DJANGO_DATABASE_HOST}" \
-                --port="${DJANGO_DATABASE_PORT}" \
-                --user="root" \
-                --password="superpasswd123" \
-                --execute="${_SETUP_SCRIPT}"
+            integration-test-setup-script: >-
+              ./.dev/scripts/ci-mysql-setup-integration-tests.sh
           - python-version: '3.10'
             django-version: 'Django~=4.1.0'
             docker-compose-services: maria-db
@@ -98,20 +87,8 @@ jobs:
               DJANGO_DATABASE_ENGINE: 'django.db.backends.mysql'
               DJANGO_DATABASE_PORT: 3307
             continue-on-error: false
-            integration-test-setup-script: |
-              _SETUP_SCRIPT="$(cat << EOM
-                CREATE DATABASE IF NOT EXISTS db;
-                GRANT ALL PRIVILEGES ON db.* TO django;
-                FLUSH PRIVILEGES;
-              EOM
-              )"
-              mysql \
-                --host="${DJANGO_DATABASE_HOST}" \
-                --port="${DJANGO_DATABASE_PORT}" \
-                --user="root" \
-                --password="superpasswd123" \
-                --execute="${_SETUP_SCRIPT}"
-
+            integration-test-setup-script: >-
+              ./.dev/scripts/ci-mysql-setup-integration-tests.sh
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
@@ -165,9 +142,8 @@ jobs:
           ${{ matrix.docker-compose-services }}
         if: ${{ matrix.docker-compose-services }}
         run: |
-          echo '${{ matrix.integration-test-setup-script }}' > setup-test.sh
-          if [ -f setup-test.sh  ]; then
-            bash setup-test.sh
+          if [ -f '${{ matrix.integration-test-setup-script }}' ]; then
+            bash '${{ matrix.integration-test-setup-script }}'
           fi
           CHECK_OUTPUT="$(poetry run python django_test_app/manage.py check 2>&1 || true)"
           echo "${CHECK_OUTPUT}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,6 +75,14 @@ jobs:
               DJANGO_DATABASE_ENGINE: 'django.db.backends.mysql'
               DJANGO_DATABASE_PORT: 3306
             continue-on-error: false
+          - python-version: '3.10'
+            django-version: 'Django~=4.1.0'
+            docker-compose-services: maria-db
+            additional-dependencies: mysqlclient
+            env:
+              DJANGO_DATABASE_ENGINE: 'django.db.backends.mysql'
+              DJANGO_DATABASE_PORT: 3307
+            continue-on-error: false
 
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 We follow Semantic Versions since the `0.1.0` release.
 
+## Version
+
+### Fixes
+
+- Fix getting the `statement_timeout` setting name on MariaDB servers
+
 
 ## Version 1.3.0
 

--- a/django_test_app/django_test_app/settings.py
+++ b/django_test_app/django_test_app/settings.py
@@ -82,6 +82,10 @@ WSGI_APPLICATION = 'django_test_app.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/2.2/ref/settings/#databases
 
+_DATABASE_NAME = os.environ.get(
+    'DJANGO_DATABASE_NAME',
+    default=os.path.join(BASE_DIR, 'db.sqlite3'),
+)
 DATABASES = {
     'default': {
         'ENGINE': os.environ.get(
@@ -90,12 +94,16 @@ DATABASES = {
         ),
         'USER': os.environ.get('DJANGO_DATABASE_USER', default=''),
         'PASSWORD': os.environ.get('DJANGO_DATABASE_PASSWORD', default=''),
-        'NAME': os.environ.get(
-            'DJANGO_DATABASE_NAME',
-            default=os.path.join(BASE_DIR, 'db.sqlite3'),
-        ),
+        'NAME': _DATABASE_NAME,
         'PORT': os.environ.get('DJANGO_DATABASE_PORT', default=''),
         'HOST': os.environ.get('DJANGO_DATABASE_HOST', default=''),
+        'TEST': {
+            'NAME': (
+                _DATABASE_NAME
+                if _DATABASE_NAME.startswith('test_')
+                else 'test_{0}'.format(_DATABASE_NAME)
+            ),
+        },
     },
 }
 

--- a/django_test_migrations/db/backends/base/configuration.py
+++ b/django_test_migrations/db/backends/base/configuration.py
@@ -15,7 +15,6 @@ class BaseDatabaseConfiguration(abc.ABC):
     """Interact with database's settings."""
 
     vendor: ClassVar[str]
-    statement_timeout: ClassVar[str]
 
     @classmethod
     def __init_subclass__(cls, **kwargs) -> None:
@@ -26,6 +25,11 @@ class BaseDatabaseConfiguration(abc.ABC):
     def __init__(self, connection: AnyConnection) -> None:
         """Bind database ``connection`` used to retrieve settings values."""
         self.connection = connection
+
+    @property
+    @abc.abstractmethod
+    def statement_timeout(self) -> str:
+        """Get `STATEMENT TIMEOUT` setting name."""
 
     @abc.abstractmethod
     def get_setting_value(self, name: str) -> DatabaseSettingValue:

--- a/django_test_migrations/db/backends/mysql/configuration.py
+++ b/django_test_migrations/db/backends/mysql/configuration.py
@@ -1,3 +1,5 @@
+from functools import cached_property
+
 from typing_extensions import final
 
 from django_test_migrations.db.backends.base.configuration import (
@@ -11,7 +13,6 @@ class DatabaseConfiguration(BaseDatabaseConfiguration):
     """Interact with MySQL database configuration."""
 
     vendor = 'mysql'
-    statement_timeout = 'MAX_EXECUTION_TIME'
 
     def get_setting_value(self, name: str) -> DatabaseSettingValue:
         """Retrieve value of MySQL database's setting with ``name``."""
@@ -23,3 +24,15 @@ class DatabaseConfiguration(BaseDatabaseConfiguration):
             if not setting_value:
                 return super().get_setting_value(name)
             return setting_value[0]
+
+    @cached_property
+    def version(self) -> str:
+        """Get MySQL DB server version."""
+        return str(self.get_setting_value('VERSION'))
+
+    @property
+    def statement_timeout(self) -> str:
+        """Get `STATEMENT TIMEOUT` setting name based on DB server version."""
+        if 'mariadb' in self.version.lower():
+            return 'MAX_STATEMENT_TIME'
+        return 'MAX_EXECUTION_TIME'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     image: mysql:8
     ports:
       - "3306:3306"
-    restart: always
+    restart: unless-stopped
     environment:
       - MYSQL_USER=django
       - MYSQL_PASSWORD=passwd123
@@ -31,7 +31,7 @@ services:
     image: mariadb:10
     ports:
       - "3307:3306"
-    restart: always
+    restart: unless-stopped
     environment:
       - MARIADB_USER=django
       - MARIADB_PASSWORD=passwd123

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,3 +25,18 @@ services:
       - MYSQL_DATABASE=test_db
       - MYSQL_ROOT_PASSWORD=superpasswd123
     command: --default-authentication-plugin=mysql_native_password
+
+  maria-db:
+    image: mariadb:10
+    ports:
+      - "3307:3306"
+    environment:
+      - MYSQL_USER=django
+      - MYSQL_PASSWORD=passwd123
+      # NOTE: MySQL container entrypoint gives user `${MYSQL_USER}` access
+      # only to `${MYSQL_DATABASE}` database, so we are setting
+      # `${MYSQL_DATABASE}` to Django default test database's name to avoid
+      # overriding `ENTRYPOINT` or `CMD`.
+      - MYSQL_DATABASE=test_db
+      - MYSQL_ROOT_PASSWORD=superpasswd123
+    command: --default-authentication-plugin=mysql_native_password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
     image: mysql:8
     ports:
       - "3306:3306"
+    restart: always
     environment:
       - MYSQL_USER=django
       - MYSQL_PASSWORD=passwd123
@@ -30,13 +31,14 @@ services:
     image: mariadb:10
     ports:
       - "3307:3306"
+    restart: always
     environment:
-      - MYSQL_USER=django
-      - MYSQL_PASSWORD=passwd123
+      - MARIADB_USER=django
+      - MARIADB_PASSWORD=passwd123
       # NOTE: MySQL container entrypoint gives user `${MYSQL_USER}` access
       # only to `${MYSQL_DATABASE}` database, so we are setting
       # `${MYSQL_DATABASE}` to Django default test database's name to avoid
       # overriding `ENTRYPOINT` or `CMD`.
-      - MYSQL_DATABASE=test_db
-      - MYSQL_ROOT_PASSWORD=superpasswd123
+      - MARIADB_DATABASE=test_db
+      - MARIADB_ROOT_PASSWORD=superpasswd123
     command: --default-authentication-plugin=mysql_native_password

--- a/tests/test_db/test_backends/test_mysql/test_configuration.py
+++ b/tests/test_db/test_backends/test_mysql/test_configuration.py
@@ -1,4 +1,5 @@
 import pytest
+from pytest_mock import MockerFixture
 
 from django_test_migrations.db.backends import mysql
 from django_test_migrations.db.backends.exceptions import (
@@ -6,7 +7,28 @@ from django_test_migrations.db.backends.exceptions import (
 )
 
 
-def test_get_setting_value(mocker):
+@pytest.mark.parametrize(('version', 'setting_name'), [
+    ('8.0.33', 'MAX_EXECUTION_TIME'),
+    ('10.11.2-MariaDB', 'MAX_STATEMENT_TIME'),
+    ('10.11.2-MariaDB-1:10.11.2+maria~ubu2204', 'MAX_STATEMENT_TIME'),
+])
+def test_statement_timeout(
+    mocker: MockerFixture,
+    version: str,
+    setting_name: str,
+) -> None:
+    """Ensure expected setting name is returned."""
+    connection_mock = mocker.MagicMock()
+    cursor_mock = connection_mock.cursor().__enter__()  # noqa: WPS609
+    cursor_mock.fetchone.return_value = (version,)
+    database_configuration = mysql.configuration.DatabaseConfiguration(
+        connection_mock,
+    )
+
+    assert database_configuration.statement_timeout == setting_name
+
+
+def test_get_setting_value(mocker: MockerFixture) -> None:
     """Ensure expected SQL query is executed."""
     setting_name = 'MAX_EXECUTION_TIME'
     connection_mock = mocker.MagicMock()
@@ -14,14 +36,16 @@ def test_get_setting_value(mocker):
     database_configuration = mysql.configuration.DatabaseConfiguration(
         connection_mock,
     )
+
     database_configuration.get_setting_value(setting_name)
+
     cursor_mock = connection_mock.cursor().__enter__()  # noqa: WPS609
     cursor_mock.execute.assert_called_once_with(
         'SELECT @@{0};'.format(setting_name),
     )
 
 
-def test_get_existing_setting_value(mocker):
+def test_get_existing_setting_value(mocker: MockerFixture) -> None:
     """Ensure setting value is returned for existing setting."""
     expected_setting_value = 74747
     connection_mock = mocker.MagicMock()
@@ -30,11 +54,13 @@ def test_get_existing_setting_value(mocker):
     database_configuration = mysql.configuration.DatabaseConfiguration(
         connection_mock,
     )
+
     setting_value = database_configuration.get_setting_value('testing_setting')
+
     assert setting_value == expected_setting_value
 
 
-def test_get_not_existing_setting_value(mocker):
+def test_get_not_existing_setting_value(mocker: MockerFixture) -> None:
     """Ensure exception is raised when setting does not exist."""
     connection_mock = mocker.MagicMock()
     cursor_mock = connection_mock.cursor().__enter__()  # noqa: WPS609
@@ -42,5 +68,6 @@ def test_get_not_existing_setting_value(mocker):
     database_configuration = mysql.configuration.DatabaseConfiguration(
         connection_mock,
     )
+
     with pytest.raises(DatabaseConfigurationSettingNotFound):
         database_configuration.get_setting_value('testing_setting')


### PR DESCRIPTION
This PRs:

+ adds MariaDB server to test matrix
+ adds simple integration tests against DB servers - simply call `python manage.py check` against DB servers
+ fixes `statement_timeout` setting getting on MariaDB server

Closes #321 