### PR TITLE
Remove Django 2.2 from supported versions in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ pip install django-test-migrations
 
 We support several `django` versions:
 
-- `2.2`
 - `3.2`
 - `4.0`
 - `4.1`


### PR DESCRIPTION
Support for Django 2.2 was dropped in django-test-migrations 1.3.0.